### PR TITLE
mean: fix non-root, use multistage builds

### DIFF
--- a/mean-k8s/Dockerfile
+++ b/mean-k8s/Dockerfile
@@ -1,27 +1,35 @@
 # This Docker image uses the latest version of the Bitnami Node 7 Docker image
-FROM bitnami/node:7
+# and uses Docker multistage builds
+
+# Use bitnami/node:7 for the build stage
+FROM bitnami/node:7 as builder
 
 # Install additional dependencies required by the app
 RUN install_packages libkrb5-dev
 
-# Copy application source code to /app directory 
+# Copy application source code to /app directory
 # of  your container
 COPY app-code /app
 
-# Actions will be performed by the user 'bitnami', so it's good practice
-# to explicitly set the required permissions
-RUN chown -R bitnami:bitnami /app /home/bitnami 
+# Install dependencies of your app, defined into package.json
+RUN npm install
 
-# Change the effective UID from 'root' to 'bitnami'
+# Use bitnami/node:7-prod for the target image
+FROM bitnami/node:7-prod
+
+# Copy the application and installed modules from the previous build stage
+COPY --from=builder /app /app
+
+# Actions will be performed by a non-root user id '1001', so it's good
+# practice to explicitly set the required permissions
+RUN chown -R 1001:1001 /app
+
+# Change the effective UID from 'root' to '1001'
 # Never run application code as 'root'!
-USER bitnami
+USER 1001
 
 # The application's directory will be the working directory
 WORKDIR /app
 
-# Install dependencies of your app, defined into package.json
-RUN npm install 
-
 # Run your app!
-CMD ["npm", "start"] 
-
+CMD ["npm", "start"]

--- a/mean-k8s/helm-chart/templates/deployment.yaml
+++ b/mean-k8s/helm-chart/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Changes:
 - bitnami/node no longer has a user named `bitnami`, specify uid `1001`
   instead
 - with multistage builds we use the size optimized production builds of
   the bitnami/node image and as a result we're are build much smaller
   images of the mean-app.