### PR TITLE
 phpfpm-k8s/helm-chart: fix service references, internalPort references

### DIFF
--- a/phpfpm-k8s/helm-chart/templates/configMap.yaml
+++ b/phpfpm-k8s/helm-chart/templates/configMap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   nginx.conf: |-
     server {
-      listen 0.0.0.0:80;
+      listen 0.0.0.0:{{ .Values.nginxService.internalPort }};
       root /app;
       location / {
         index index.html index.php;

--- a/phpfpm-k8s/helm-chart/templates/configMap.yaml
+++ b/phpfpm-k8s/helm-chart/templates/configMap.yaml
@@ -16,7 +16,7 @@ data:
         index index.html index.php;
       }
       location ~ \.php$ {
-        fastcgi_pass phpfpm-php-app-phpfpm:9000;
+        fastcgi_pass {{ template "fullname" . }}-phpfpm:9000;
         fastcgi_index index.php;
         include fastcgi.conf;
       }

--- a/phpfpm-k8s/helm-chart/templates/deployment.yaml
+++ b/phpfpm-k8s/helm-chart/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         ports:
         - name: http
-          containerPort: 80
+          containerPort: {{ .Values.nginxService.internalPort }}
         - name: https
           containerPort: 443
         livenessProbe:


### PR DESCRIPTION
There were some hard-coded service (DNS) names and port numbers that I had to replace to make the example work.