### PR TITLE
updating as old repo jessie doesn't exist

### DIFF
--- a/java-k8s/app-code/utils/Dockerfile
+++ b/java-k8s/app-code/utils/Dockerfile
@@ -1,10 +1,13 @@
-FROM bitnami/minideb-extras:jessie-r15
+FROM bitnami/minideb-extras:jessie
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install related packages
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
-    install_packages ca-certificates-java/jessie-backports openjdk-8-jdk-headless bzip2
-
+RUN echo "deb [check-valid-until=no] http://ftp.debian.org/debian/ stretch  main" > /etc/apt/sources.list.d/jessie.list
+#RUN apt-get -o Acquire::Check-Valid-Until=false update -- if repo does create issue
+RUN apt-get update
+RUN apt-get install bzip2 -y
+RUN apt install -t stretch ca-certificates-java -y
+RUN apt install -t stretch --no-install-recommends openjdk-8-jdk-headless openjdk-8-jre-headless  -y 
 RUN mkdir /bitnami
 WORKDIR /bitnami
-ENTRYPOINT chown -R bitnami:bitnami /bitnami &&  su bitnami -c './mvnw -Pprod clean package'
+ENTRYPOINT chown -R bitnami:bitnami /bitnami &&  su bitnami -c './mvnw -Pprod clean package


### PR DESCRIPTION
Old jessie repo does not exist, due to which it does not allow to download java-headless package. For any further issue related to this I can be reached at kapsofficial@gmail.com