### PR TITLE
Templatize apiversion for deployment and ingress

### DIFF
--- a/go-k8s/helm-chart/templates/_helpers.tpl
+++ b/go-k8s/helm-chart/templates/_helpers.tpl
@@ -14,3 +14,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/go-k8s/helm-chart/templates/deployment.yaml
+++ b/go-k8s/helm-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/phpfpm-k8s/helm-chart/templates/_helpers.tpl
+++ b/phpfpm-k8s/helm-chart/templates/_helpers.tpl
@@ -21,3 +21,26 @@ We truncate at  63 | trimSuffix "-" chars because some Kubernetes name fields ar
 {{- define "mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc  63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/phpfpm-k8s/helm-chart/templates/deployment.yaml
+++ b/phpfpm-k8s/helm-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-phpfpm
@@ -25,7 +25,7 @@ spec:
           initialDelaySeconds: 10
           timeoutSeconds: 5
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-nginx
@@ -64,5 +64,5 @@ spec:
           mountPath: /bitnami/nginx/conf/vhosts
       volumes:
       - name: nginx-config
-        configMap: 
-          name: {{ template "fullname" . }}             
+        configMap:
+          name: {{ template "fullname" . }}

--- a/phpfpm-k8s/helm-chart/templates/ingress.yaml
+++ b/phpfpm-k8s/helm-chart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/rust-k8s/helm-chart/rust-k8s/templates/_helpers.tpl
+++ b/rust-k8s/helm-chart/rust-k8s/templates/_helpers.tpl
@@ -14,3 +14,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/rust-k8s/helm-chart/rust-k8s/templates/deployment.yaml
+++ b/rust-k8s/helm-chart/rust-k8s/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/swift-k8s/helm-chart/templates/_helpers.tpl
+++ b/swift-k8s/helm-chart/templates/_helpers.tpl
@@ -14,3 +14,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/swift-k8s/helm-chart/templates/deployment.yaml
+++ b/swift-k8s/helm-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/swift-k8s/helm-chart/templates/ingress.yaml
+++ b/swift-k8s/helm-chart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
As kubernetes has deprecated some versions of its api objects in the latest releases we need to templatize them in order to be compatible with latest versions.

- Add template for deployment api version
- Add template for ingress api version 
- Use them in `deployment.yaml` and `ingress.yaml`

fixes #23