### PR TITLE
Fix error in nginx configuration

### DIFF
--- a/phpfpm-k8s/app-code/docker-compose.yml
+++ b/phpfpm-k8s/app-code/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - '80:80'
       - '443:443'
     volumes:
-      - ./vhosts:/bitnami/nginx/conf/vhosts
+      - ./vhosts:/bitnami/nginx/conf/server_blocks
   mariadb:
     image: bitnami/mariadb:latest
     environment:

--- a/phpfpm-k8s/helm-chart/templates/deployment.yaml
+++ b/phpfpm-k8s/helm-chart/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           timeoutSeconds: 1
         volumeMounts:
         - name: nginx-config
-          mountPath: /bitnami/nginx/conf/vhosts
+          mountPath: /bitnami/nginx/conf/server_blocks
       volumes:
       - name: nginx-config
         configMap:


### PR DESCRIPTION
When trying to deploy the helm chart phpfpm
It was failing with: 
```
nginx 11:21:11.85 ERROR ==> Custom server blocks files were found inside '/bitnami/nginx/conf/vhosts'. This configuration is not supported anymore. Please mount your custom server blocks config files at '/opt/bitnami/nginx/conf/server_blocks' instead.
```
The fix is already applied (and taken from): https://github.com/bitnami/bitnami-docker-php-fpm/pull/124/files